### PR TITLE
Incorporate minimum value into 99 Bottles verse

### DIFF
--- a/lib/bottles.rb
+++ b/lib/bottles.rb
@@ -67,7 +67,8 @@ class BottleNumber
       BottleNumberMin.new(
         number,
         max: max,
-        min: min
+        min: min,
+        bottle_number: bottle_number
       )
     else
       bottle_number

--- a/lib/bottles.rb
+++ b/lib/bottles.rb
@@ -129,3 +129,21 @@ class BottleNumber6 < BottleNumber
     "six-pack"
   end
 end
+
+class BottleNumberMin < BottleNumber
+  def quantity
+    "1"
+  end
+
+  def container
+    "bottle"
+  end
+
+  def action
+    "Go to the store and buy some more"
+  end
+
+  def successor
+    BottleNumber.for(max, max: max, min: min)
+  end
+end

--- a/lib/bottles.rb
+++ b/lib/bottles.rb
@@ -31,7 +31,7 @@ class BottleVerse
     end
 
     def lyrics(number, max: self.max, min: self.min)
-      new(BottleNumber.for(number, max: max, min: self.min)).lyrics
+      new(BottleNumber.for(number, max: max, min: min)).lyrics
     end
   end
 
@@ -52,6 +52,12 @@ end
 
 class BottleNumber
   def self.for(number, max:, min:)
+    return BottleNumberMin.new(
+      number,
+      max: max,
+      min: min
+    ) if number == min
+
     case number
     when 0
       BottleNumber0

--- a/lib/bottles.rb
+++ b/lib/bottles.rb
@@ -30,8 +30,8 @@ class BottleVerse
       0
     end
 
-    def lyrics(number, max: self.max)
-      new(BottleNumber.for(number, max: max)).lyrics
+    def lyrics(number, max: self.max, min: self.min)
+      new(BottleNumber.for(number, max: max, min: self.min)).lyrics
     end
   end
 

--- a/lib/bottles.rb
+++ b/lib/bottles.rb
@@ -92,7 +92,7 @@ class BottleNumber
   end
 
   def successor
-    BottleNumber.for(number - 1, max: max)
+    BottleNumber.for(number - 1, max: max, min: min)
   end
 end
 
@@ -106,7 +106,7 @@ class BottleNumber0 < BottleNumber
   end
 
   def successor
-    BottleNumber.for(max, max: max)
+    BottleNumber.for(max, max: max, min: min)
   end
 end
 

--- a/lib/bottles.rb
+++ b/lib/bottles.rb
@@ -15,7 +15,7 @@ class CountdownSong
   end
 
   def verse(number)
-    verse_template.lyrics(number, max: max)
+    verse_template.lyrics(number, max: max, min: min)
   end
 end
 

--- a/lib/bottles.rb
+++ b/lib/bottles.rb
@@ -135,7 +135,7 @@ end
 class BottleNumberMin < BottleNumber
   def initialize(number, max:, min:, bottle_number: nil)
     super(number, max: max, min: min)
-    @bottle_number = BottleNumber.for(number, max: max, min: nil)
+    @bottle_number = bottle_number ? bottle_number : BottleNumber.for(number, max: max, min: nil)
   end
 
   def quantity

--- a/lib/bottles.rb
+++ b/lib/bottles.rb
@@ -61,11 +61,11 @@ class BottleNumber
       BottleNumber6
     else
       BottleNumber
-    end.new(number, max: max)
+    end.new(number, max: max, min: min)
   end
 
   attr_reader :number, :max, :min
-  def initialize(number, max:, min: 0)
+  def initialize(number, max:, min:)
     @number = number
     @max = max
     @min = min

--- a/lib/bottles.rb
+++ b/lib/bottles.rb
@@ -64,10 +64,11 @@ class BottleNumber
     end.new(number, max: max)
   end
 
-  attr_reader :number, :max
-  def initialize(number, max:)
+  attr_reader :number, :max, :min
+  def initialize(number, max:, min: 0)
     @number = number
     @max = max
+    @min = min
   end
 
   def to_s

--- a/lib/bottles.rb
+++ b/lib/bottles.rb
@@ -51,7 +51,7 @@ end
 
 
 class BottleNumber
-  def self.for(number, max:, min: 0)
+  def self.for(number, max:, min:)
     case number
     when 0
       BottleNumber0

--- a/lib/bottles.rb
+++ b/lib/bottles.rb
@@ -51,7 +51,7 @@ end
 
 
 class BottleNumber
-  def self.for(number, max:)
+  def self.for(number, max:, min: 0)
     case number
     when 0
       BottleNumber0

--- a/lib/bottles.rb
+++ b/lib/bottles.rb
@@ -52,13 +52,7 @@ end
 
 class BottleNumber
   def self.for(number, max:, min:)
-    return BottleNumberMin.new(
-      number,
-      max: max,
-      min: min
-    ) if number == min
-
-    case number
+    bottle_number = case number
     when 0
       BottleNumber0
     when 1
@@ -68,6 +62,16 @@ class BottleNumber
     else
       BottleNumber
     end.new(number, max: max, min: min)
+
+    if (number == min)
+      BottleNumberMin.new(
+        number,
+        max: max,
+        min: min
+      )
+    else
+      bottle_number
+    end
   end
 
   attr_reader :number, :max, :min

--- a/lib/bottles.rb
+++ b/lib/bottles.rb
@@ -129,8 +129,8 @@ class BottleNumber6 < BottleNumber
 end
 
 class BottleNumberMin < BottleNumber
-  def initialize(number, max:, min:)
-    super
+  def initialize(number, max:, min:, bottle_number: nil)
+    super(number, max: max, min: min)
     @bottle_number = BottleNumber.for(number, max: max, min: nil)
   end
 

--- a/lib/bottles.rb
+++ b/lib/bottles.rb
@@ -134,9 +134,9 @@ class BottleNumber6 < BottleNumber
 end
 
 class BottleNumberMin < BottleNumber
-  def initialize(number, max:, min:, bottle_number: nil)
+  def initialize(number, max:, min:, bottle_number:)
     super(number, max: max, min: min)
-    @bottle_number = bottle_number ? bottle_number : BottleNumber.for(number, max: max, min: nil)
+    @bottle_number = bottle_number
   end
 
   def quantity

--- a/lib/bottles.rb
+++ b/lib/bottles.rb
@@ -131,12 +131,17 @@ class BottleNumber6 < BottleNumber
 end
 
 class BottleNumberMin < BottleNumber
+  def initialize(number, max:, min:)
+    super
+    @bottle_number = BottleNumber.for(number, max: max, min: nil)
+  end
+
   def quantity
-    "1"
+    @bottle_number.quantity
   end
 
   def container
-    "bottle"
+    @bottle_number.container
   end
 
   def action

--- a/lib/bottles.rb
+++ b/lib/bottles.rb
@@ -106,14 +106,6 @@ class BottleNumber0 < BottleNumber
   def quantity
     "no more"
   end
-
-  def action
-    "Go to the store and buy some more"
-  end
-
-  def successor
-    BottleNumber.for(max, max: max, min: min)
-  end
 end
 
 class BottleNumber1 < BottleNumber

--- a/test/bottles_test.rb
+++ b/test/bottles_test.rb
@@ -137,6 +137,17 @@ class BottleNumberMinTest < Minitest::Test
       BottleNumberMin.new(1, max: 99, min: 1)
     ).lyrics
   end
+
+  def test_verse_0
+    expected =
+      "No more bottles of beer on the wall, " +
+      "no more bottles of beer.\n" +
+      "Go to the store and buy some more, " +
+      "1 six-pack of beer on the wall.\n"
+    assert_equal expected, BottleVerse.new(
+      BottleNumberMin.new(0, max: 6, min: 0)
+    ).lyrics
+  end
 end
 
 class CountdownSongTest < Minitest::Test

--- a/test/bottles_test.rb
+++ b/test/bottles_test.rb
@@ -126,6 +126,18 @@ class BottleVerseTest < Minitest::Test
   end
 end
 
+class BottleNumberMinTest < Minitest::Test
+  def test_verse_1
+    expected =
+      "1 bottle of beer on the wall, " +
+      "1 bottle of beer.\n" +
+      "Go to the store and buy some more, " +
+      "99 bottles of beer on the wall.\n"
+    assert_equal expected, BottleVerse.new(
+      BottleNumberMin.new(1, max: 99, min: 1)
+    ).lyrics
+  end
+end
 
 class CountdownSongTest < Minitest::Test
   def test_verse

--- a/test/bottles_test.rb
+++ b/test/bottles_test.rb
@@ -250,7 +250,6 @@ Go to the store and buy some more, 7 bottles of beer on the wall.
   end
 
   def test_custom_max_min_bottles_song
-    skip
     expected = <<-SONG
 1 six-pack of beer on the wall, 1 six-pack of beer.
 Take one down and pass it around, 5 bottles of beer on the wall.

--- a/test/bottles_test.rb
+++ b/test/bottles_test.rb
@@ -181,7 +181,7 @@ class CountdownSongTest < Minitest::Test
 end
 
 class Bottles99IntegrationTest < Minitest::Test
-  def test_partial_7_bottles_song
+  def test_custom_max_bottles_song
     expected = <<-SONG
 7 bottles of beer on the wall, 7 bottles of beer.
 Take one down and pass it around, 1 six-pack of beer on the wall.
@@ -212,8 +212,39 @@ Go to the store and buy some more, 7 bottles of beer on the wall.
       expected,
       CountdownSong.new(
         verse_template: BottleVerse,
-        max: 7,
-        min: 0
+        max: 7
+      ).song
+    )
+  end
+
+  def test_custom_max_min_bottles_song
+    skip
+    expected = <<-SONG
+1 six-pack of beer on the wall, 1 six-pack of beer.
+Take one down and pass it around, 5 bottles of beer on the wall.
+
+5 bottles of beer on the wall, 5 bottles of beer.
+Take one down and pass it around, 4 bottles of beer on the wall.
+
+4 bottles of beer on the wall, 4 bottles of beer.
+Take one down and pass it around, 3 bottles of beer on the wall.
+
+3 bottles of beer on the wall, 3 bottles of beer.
+Take one down and pass it around, 2 bottles of beer on the wall.
+
+2 bottles of beer on the wall, 2 bottles of beer.
+Take one down and pass it around, 1 bottle of beer on the wall.
+
+1 bottle of beer on the wall, 1 bottle of beer.
+Go to the store and buy some more, 1 six-pack of beer on the wall.
+    SONG
+
+    assert_equal(
+      expected,
+      CountdownSong.new(
+        verse_template: BottleVerse,
+        max: 6,
+        min: 1
       ).song
     )
   end

--- a/test/bottles_test.rb
+++ b/test/bottles_test.rb
@@ -133,7 +133,12 @@ class BottleNumberMinTest < Minitest::Test
       "Go to the store and buy some more, " +
       "99 bottles of beer on the wall.\n"
     assert_equal expected, BottleVerse.new(
-      BottleNumberMin.new(1, max: 99, min: 1)
+      BottleNumberMin.new(
+        1,
+        max: 99,
+        min: 1,
+        bottle_number: BottleNumber.for(1, max: 99, min: 1)
+      )
     ).lyrics
   end
 
@@ -144,7 +149,12 @@ class BottleNumberMinTest < Minitest::Test
       "Go to the store and buy some more, " +
       "1 six-pack of beer on the wall.\n"
     assert_equal expected, BottleVerse.new(
-      BottleNumberMin.new(0, max: 6, min: 0)
+      BottleNumberMin.new(
+        0,
+        max: 6,
+        min: 0,
+        bottle_number: BottleNumber.for(0, max: 6, min: 0)
+      )
     ).lyrics
   end
 end

--- a/test/bottles_test.rb
+++ b/test/bottles_test.rb
@@ -21,7 +21,7 @@ class VerseFake
       5
     end
 
-    def lyrics(number, max: nil)
+    def lyrics(number, max: nil, min: nil)
       "This is verse #{number}.\n"
     end
   end

--- a/test/bottles_test.rb
+++ b/test/bottles_test.rb
@@ -98,7 +98,6 @@ class BottleVerseTest < Minitest::Test
   end
 
   def test_verse_1_with_explicit_min_value
-    skip
     expected =
       "1 bottle of beer on the wall, " +
       "1 bottle of beer.\n" +

--- a/test/bottles_test.rb
+++ b/test/bottles_test.rb
@@ -97,6 +97,16 @@ class BottleVerseTest < Minitest::Test
      assert_equal expected, BottleVerse.lyrics(1)
   end
 
+  def test_verse_1_with_explicit_min_value
+    skip
+    expected =
+      "1 bottle of beer on the wall, " +
+      "1 bottle of beer.\n" +
+      "Go to the store and buy some more, " +
+      "99 bottles of beer on the wall.\n"
+     assert_equal expected, BottleVerse.lyrics(1, min: 1)
+  end
+
   def test_verse_0
     expected =
       "No more bottles of beer on the wall, " +


### PR DESCRIPTION
Introduce the requirement that when `CountdownSong` specifies a `min:` parameter, the final `BottleVerse` should:
- Display `Go to the store and buy some more` for `action`
- Retain what `quantity` and `container` typically return for the minimum bottle number
- Display the `max` bottle number for `successor`

For example, the last verse of this song:
```ruby
CountdownSong.new(
  verse_template: BottleVerse,
  max: 6,
  min: 1
).song
```

Should be:
```
1 bottle of beer on the wall, 1 bottle of beer.
Go to the store and buy some more, 1 six-pack of beer on the wall.
```

Instead of:
```
1 bottle of beer on the wall, 1 bottle of beer.
Take it down and pass it around, no more bottles of beer on the wall.
```

The commits in this PR introduce an integration test with the new requirement, and then make the incremental changes necessary to make the test pass, according to the principles described in [99 Bottles of OOP](https://sandimetz.com/99bottles) by Sandi Metz.

### First round of changes (till [this commit](https://github.com/trishrempel/99bottles_ruby/pull/2/commits/54cb31d3e9aab1fb0a2931940eaacc3c0eb42296))

- Passed the `min:` parameter to `BottleNumber.for` and `BottleVerse`
- Created a [`BottleNumberMin` subclass](https://github.com/trishrempel/99bottles_ruby/pull/2/commits/e99af66b1bc6944c549b0f1cd53772d5ff94fb42#diff-4a518b0c07ab8bd035aee31c0377dea21c5ad923a57d8cb52af902444979c013) of `BottleNumber`. It uses the `BottleNumber.for` factory to construct a `BottleNumber` with a `min:` value of `nil` and uses it as a proxy for `quantity` and `container`
- Updated `BottleNumber.for` to return early with a `BottleNumberMin` instance if `number` equals `min:`
- Updated `CountdownSong#verse` to pass a `min:` value to `verse_template.lyrics`
- Removed the now unnecessary duplicate methods `#action` and `#successor` from `BottleNumber0`

#### Problem

I wasn't fond of this line in `BottleNumberMin#new`:
```ruby
@bottle_number = BottleNumber.for(number, max: max, min: nil)
```

Here, it uses the `BottleNumber.for` factory to construct a `BottleNumber` for `number` so that it can be used as a proxy for `quantity` and `container`. In order to bypass constructing a `BottleNumberMin` once again, it explicitly passes `min:` as `nil`. 

Doing this presumes an intimate knowledge of the inner workings of `BottleNumber.for` and introduces tight coupling and fragility to the code, according to the principles taught in 99 Bottles of OOP.

### Second round of changes (from [this commit](https://github.com/trishrempel/99bottles_ruby/pull/2/commits/54cb31d3e9aab1fb0a2931940eaacc3c0eb42296) till [this commit](https://github.com/trishrempel/99bottles_ruby/pull/2/commits/439cbcf69a312f6f7053306441389ebc763b7529))

I wanted to find a way to make `BottleNumberMin` less responsible and knowledgeable of the `BottleNumber.for` factory. To do this, I needed to shift the responsibility to `BottleNumber.for`.

- Updated `BottleNumberMin#new` to accept a `bottle_number` parameter, to act as the proxy for `#quantity` and `#container`
- Updated `BottleNumber.for` to first construct a `BottleNumber` for the `number` parameter. If `number` is equal to `min`, return a new `BottleNumberMin`, passing the usual properties and the `BottleNumber`. Otherwise, return the `BottleNumber`.

Follow the commits to see how I made the changes incrementally while keeping tests green.

#### Problem

`BottleNumber.for` now has a newline between two blocks of code, which usually represents a method doing too many things. The first block constructs a `BottleNumber` according to `number`. The second block decides whether to construct a `BottleNumberMin` with the already created `BottleNumber` as a parameter, or to return the existing `BottleNumber`.

To me, these are still clearly the responsibility of the `BottleNumber` factory. It might be possible to move these two blocks to their own private methods. However, I don't think this would significantly improve clarity and readability, and because `BottleNumber.for` is a class method, I think introducing more class methods that are private would be even more clunky and confusing.